### PR TITLE
Add --detached flag to project create and add-repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ go test -v -race -count=1 ./internal/git/...
 | `cmd/projector` | Cobra root + one file per subcommand (`projects.go`, `list.go`, `create.go`, `desc.go`, `open.go`, `path.go`, `addrepo.go`, `archive.go`, `restore.go`, `delete.go`, `version.go`). No business logic — delegate to internal packages. |
 | `internal/config` | `GlobalConfig` struct, `Load`/`Save`/`ResolveBase`/`Validate`. TOML I/O for `~/.projector/projector-config.toml`. |
 | `internal/project` | `ProjectConfig` struct, `Load`/`Save`/`ListAll`/`FindProjectDir`/`ValidateName`/`DiscoverWorktrees`. TOML I/O for `<projects-dir>/<name>/.projector.toml`. |
-| `internal/git` | Thin wrappers around the `git` executable: `RunGit`, `WorktreeAdd`, `WorktreeRemove`, `WorktreeList`, `StatusPorcelain`, `RefExists`, `BranchExists`, `CurrentBranch`, `AvailableBranchName`, `Remotes`, `RemoteForRef`, `Fetch`, `HasUnpushedCommits`, `MinVersionCheck`. |
+| `internal/git` | Thin wrappers around the `git` executable: `RunGit`, `WorktreeAdd`, `WorktreeAddDetached`, `WorktreeRemove`, `WorktreeList`, `StatusPorcelain`, `RefExists`, `BranchExists`, `CurrentBranch`, `AvailableBranchName`, `Remotes`, `RemoteForRef`, `Fetch`, `HasUnpushedCommits`, `HeadSHA`, `MinVersionCheck`. |
 | `internal/repo` | `Repo` struct, `Discover` (non-recursive scan of search dirs), `ResolveRepos` (name or abs-path lookup). |
 | `internal/tui` | `SelectRepos` (huh multi-select), `SelectEditor` (huh single-select with installed/not-installed annotations), `InitConfig` (huh first-time setup form). |
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(MODULE)
 	@echo "Built ./$(BINARY) — run './$(BINARY) --help' to get started"
 
-install:
-	go install -ldflags "$(LDFLAGS)" $(MODULE)
+install: build
+	cp $(BINARY) $(shell go env GOPATH)/bin/$(BINARY)
 
 test:
 	go test -v -race -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ pj project create my-feature --base HEAD
 
 **Branch base**: By default branches are created from `origin/main` → `HEAD` (configurable per-repo via `[repos.<name>]` in the config file). Use `--base <ref>` to specify any git ref explicitly. When `--from` is used without `--base`, each repo branches from the corresponding worktree branch of the source project.
 
+**Detached HEAD**: Use `--detached` to skip branch creation entirely. Worktrees are created in detached HEAD state, letting you decide later whether and what to name a branch. Works with all other flags (`--base`, `--from`, etc.).
+
+```bash
+pj project create my-feature --detached
+pj project create my-feature --detached --base origin/release-2.0
+```
+
 **Auto-fetch**: When the resolved base ref is a remote-tracking ref (e.g. `origin/main`), `pj` automatically runs `git fetch` for that remote before creating the worktree, so the branch is always created from an up-to-date ref.
 
 **Rollback**: If any worktree fails to be created, all previously created worktrees and the project directory are removed automatically.
@@ -234,6 +241,9 @@ pj project add-repo new-repo /abs/path/to/another-repo
 
 # Specify project explicitly (by name) and repos
 pj project add-repo my-feature new-repo
+
+# Add repos in detached HEAD state (no branch created)
+pj project add-repo --detached new-repo
 ```
 
 #### `pj project desc [project]`

--- a/cmd/projector/addrepo.go
+++ b/cmd/projector/addrepo.go
@@ -17,6 +17,8 @@ import (
 )
 
 func newAddRepoCmd() *cobra.Command {
+	var detached bool
+
 	cmd := &cobra.Command{
 		Use:   "add-repo [repos...]",
 		Short: "Add one or more repositories to a project",
@@ -131,21 +133,43 @@ func newAddRepoCmd() *cobra.Command {
 					return fmt.Errorf("resolve base for %s: %w", r.Name, err)
 				}
 
-				branchName, err := git.AvailableBranchName(r.Path, projectName, now)
+				// Fetch before using a remote-tracking ref so it is up to date.
+				remote, err := git.RemoteForRef(r.Path, base)
 				if err != nil {
-					return fmt.Errorf("branch name for %s: %w", r.Name, err)
+					return fmt.Errorf("check remote for %s: %w", r.Name, err)
+				}
+				if remote != "" {
+					fmt.Printf("  fetching %s in %s…\n", remote, r.Name)
+					if err := git.Fetch(r.Path, remote); err != nil {
+						return fmt.Errorf("fetch %s in %s: %w", remote, r.Name, err)
+					}
 				}
 
 				worktreePath := filepath.Join(projectDir, r.Name+"+"+projectName)
-				if err := git.WorktreeAdd(r.Path, worktreePath, base, branchName, true); err != nil {
-					return fmt.Errorf("add worktree for %s: %w", r.Name, err)
+
+				if detached {
+					if err := git.WorktreeAddDetached(r.Path, worktreePath, base); err != nil {
+						return fmt.Errorf("add worktree for %s: %w", r.Name, err)
+					}
+					fmt.Printf("  added worktree: %s (detached at %s)\n", worktreePath, base)
+				} else {
+					branchName, err := git.AvailableBranchName(r.Path, projectName, now)
+					if err != nil {
+						return fmt.Errorf("branch name for %s: %w", r.Name, err)
+					}
+
+					if err := git.WorktreeAdd(r.Path, worktreePath, base, branchName, true); err != nil {
+						return fmt.Errorf("add worktree for %s: %w", r.Name, err)
+					}
+					fmt.Printf("  added worktree: %s (branch: %s)\n", worktreePath, branchName)
 				}
-				fmt.Printf("  added worktree: %s (branch: %s)\n", worktreePath, branchName)
 			}
 
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&detached, "detached", false, "Create worktrees in detached HEAD state (no branch)")
 
 	return cmd
 }

--- a/cmd/projector/archive.go
+++ b/cmd/projector/archive.go
@@ -36,8 +36,10 @@ func newArchiveCmd() *cobra.Command {
 				return fmt.Errorf("discover worktrees: %w", err)
 			}
 
-			// Pre-validate: check all worktrees are clean
+			// Pre-validate: check all worktrees are clean and capture HEAD SHAs
+			// for detached worktrees (must be done before removal).
 			var dirtyRepos []string
+			detachedSHAs := map[string]string{} // worktreePath → SHA
 			for _, wt := range worktrees {
 				clean, lines, err := git.StatusPorcelain(wt.WorktreePath)
 				if err != nil {
@@ -45,6 +47,13 @@ func newArchiveCmd() *cobra.Command {
 				}
 				if !clean {
 					dirtyRepos = append(dirtyRepos, fmt.Sprintf("  %s (%d modified files)", wt.RepoName, len(lines)))
+				}
+				if wt.Branch == "" {
+					sha, err := git.HeadSHA(wt.WorktreePath)
+					if err != nil {
+						return fmt.Errorf("get HEAD SHA for detached worktree %s: %w", wt.RepoName, err)
+					}
+					detachedSHAs[wt.WorktreePath] = sha
 				}
 			}
 			if len(dirtyRepos) > 0 {
@@ -122,12 +131,16 @@ func newArchiveCmd() *cobra.Command {
 			now := time.Now().UTC()
 			var records []project.WorktreeRecord
 			for _, wt := range worktrees {
-				records = append(records, project.WorktreeRecord{
+				record := project.WorktreeRecord{
 					RepoName:     wt.RepoName,
 					RepoPath:     wt.RepoPath,
 					WorktreePath: wt.WorktreePath,
 					Branch:       wt.Branch,
-				})
+				}
+				if sha, ok := detachedSHAs[wt.WorktreePath]; ok {
+					record.Commit = sha
+				}
+				records = append(records, record)
 			}
 			p.Project.Status = project.StatusArchived
 			p.Project.ArchivedAt = &now

--- a/cmd/projector/create.go
+++ b/cmd/projector/create.go
@@ -21,6 +21,7 @@ func newCreateCmd() *cobra.Command {
 		fromProject string
 		empty       bool
 		base        string
+		detached    bool
 	)
 
 	cmd := &cobra.Command{
@@ -160,23 +161,36 @@ func newCreateCmd() *cobra.Command {
 					}
 				}
 
-				// Find available branch name
-				branchName, err := git.AvailableBranchName(r.Path, name, now)
-				if err != nil {
-					rollback()
-					return fmt.Errorf("branch name for %s: %w", r.Name, err)
-				}
-
 				worktreePath := filepath.Join(projectDir, r.Name+"+"+name)
-				if err := git.WorktreeAdd(r.Path, worktreePath, repoBase, branchName, true); err != nil {
-					rollback()
-					return fmt.Errorf("add worktree for %s: %w", r.Name, err)
+
+				if detached {
+					if err := git.WorktreeAddDetached(r.Path, worktreePath, repoBase); err != nil {
+						rollback()
+						return fmt.Errorf("add worktree for %s: %w", r.Name, err)
+					}
+					created = append(created, struct {
+						repoPath     string
+						worktreePath string
+					}{r.Path, worktreePath})
+					fmt.Printf("  created worktree: %s (detached at %s)\n", worktreePath, repoBase)
+				} else {
+					// Find available branch name
+					branchName, err := git.AvailableBranchName(r.Path, name, now)
+					if err != nil {
+						rollback()
+						return fmt.Errorf("branch name for %s: %w", r.Name, err)
+					}
+
+					if err := git.WorktreeAdd(r.Path, worktreePath, repoBase, branchName, true); err != nil {
+						rollback()
+						return fmt.Errorf("add worktree for %s: %w", r.Name, err)
+					}
+					created = append(created, struct {
+						repoPath     string
+						worktreePath string
+					}{r.Path, worktreePath})
+					fmt.Printf("  created worktree: %s (branch: %s)\n", worktreePath, branchName)
 				}
-				created = append(created, struct {
-					repoPath     string
-					worktreePath string
-				}{r.Path, worktreePath})
-				fmt.Printf("  created worktree: %s (branch: %s)\n", worktreePath, branchName)
 			}
 
 			// Write .projector.toml
@@ -200,7 +214,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&fromProject, "from", "", "Copy repo list from an existing project")
 	cmd.Flags().BoolVar(&empty, "empty", false, "Create an empty project with no repos")
 	cmd.Flags().StringVar(&base, "base", "", "Git ref to branch from (branch, tag, SHA, or remote ref such as origin/main); remote refs are fetched automatically")
+	cmd.Flags().BoolVar(&detached, "detached", false, "Create worktrees in detached HEAD state (no branch)")
 
 	return cmd
 }
-

--- a/cmd/projector/desc.go
+++ b/cmd/projector/desc.go
@@ -42,9 +42,10 @@ func newDescCmd() *cobra.Command {
 
 // worktreeStatus pairs a live WorktreeInfo with its git status.
 type worktreeStatus struct {
-	info  project.WorktreeInfo
-	clean bool
-	lines []string // git status --short lines, populated when dirty
+	info   project.WorktreeInfo
+	clean  bool
+	lines  []string // git status --short lines, populated when dirty
+	commit string   // archived commit SHA (for detached worktrees)
 }
 
 // collectWorktreeStatuses gathers live worktree info and git status for active projects,
@@ -60,6 +61,7 @@ func collectWorktreeStatuses(projectDir string, p *project.ProjectConfig) ([]wor
 					WorktreePath: wt.WorktreePath,
 					Branch:       wt.Branch,
 				},
+				commit: wt.Commit,
 			})
 		}
 		return statuses, nil
@@ -100,7 +102,11 @@ func descSummary(projectDir string, p *project.ProjectConfig) error {
 		default:
 			statusStr = fmt.Sprintf("dirty (%d)", len(s.lines))
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", s.info.RepoName, s.info.Branch, statusStr)
+		branchDisplay := s.info.Branch
+		if branchDisplay == "" {
+			branchDisplay = "(detached)"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", s.info.RepoName, branchDisplay, statusStr)
 	}
 	w.Flush()
 	return nil
@@ -124,11 +130,15 @@ func descVerbose(projectDir string, p *project.ProjectConfig) error {
 	for _, s := range statuses {
 		fmt.Println()
 
+		branchDisplay := s.info.Branch
+		if branchDisplay == "" {
+			branchDisplay = detachedDisplay(s)
+		}
 		dirty := p.Project.Status == project.StatusActive && !s.clean
 		if dirty {
-			fmt.Fprintf(os.Stdout, "%s  [%s]  dirty\n", s.info.RepoName, s.info.Branch)
+			fmt.Fprintf(os.Stdout, "%s  [%s]  dirty\n", s.info.RepoName, branchDisplay)
 		} else {
-			fmt.Fprintf(os.Stdout, "%s  [%s]\n", s.info.RepoName, s.info.Branch)
+			fmt.Fprintf(os.Stdout, "%s  [%s]\n", s.info.RepoName, branchDisplay)
 		}
 
 		// %-6s aligns "path" (4) and "status" (6) to the same value column.
@@ -147,4 +157,17 @@ func descVerbose(projectDir string, p *project.ProjectConfig) error {
 		}
 	}
 	return nil
+}
+
+// detachedDisplay returns a display string for a detached worktree.
+// For active worktrees it reads HEAD from disk; for archived ones it uses the stored commit.
+func detachedDisplay(s worktreeStatus) string {
+	sha, err := git.HeadSHA(s.info.WorktreePath)
+	if err != nil || len(sha) < 7 {
+		sha = s.commit
+	}
+	if len(sha) >= 7 {
+		return sha[:7] + " (detached)"
+	}
+	return "(detached)"
 }

--- a/cmd/projector/restore.go
+++ b/cmd/projector/restore.go
@@ -45,6 +45,22 @@ func newRestoreCmd() *cobra.Command {
 					continue
 				}
 
+				if record.Branch == "" {
+					// Detached worktree: restore in detached HEAD state.
+					commitish := record.Commit
+					if commitish == "" {
+						commitish = "HEAD" // fallback for legacy records
+					}
+					if err := git.WorktreeAddDetached(record.RepoPath, record.WorktreePath, commitish); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: restore detached %s: %v, skipping\n", record.RepoName, err)
+						skipped = append(skipped, record.RepoName)
+						continue
+					}
+					fmt.Printf("  restored: %s → %s (detached)\n", record.RepoName, record.WorktreePath)
+					restored = append(restored, record.RepoName)
+					continue
+				}
+
 				// Check if the branch still exists
 				branchExists, err := git.BranchExists(record.RepoPath, record.Branch)
 				if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -34,7 +34,10 @@ func RunGit(workingDir string, args ...string) (string, error) {
 func WorktreeAdd(repoPath, worktreePath, base, branch string, createBranch bool) error {
 	args := []string{"worktree", "add"}
 	if createBranch {
-		args = append(args, "-b", branch)
+		// Use -c to prevent the new branch from automatically tracking the
+		// remote base ref (e.g. origin/main) as its upstream. Users can set
+		// the upstream manually if needed.
+		args = []string{"-c", "branch.autoSetupMerge=false", "worktree", "add", "-b", branch}
 	}
 	args = append(args, worktreePath)
 	if base != "" {
@@ -51,6 +54,24 @@ func WorktreeAdd(repoPath, worktreePath, base, branch string, createBranch bool)
 		return fmt.Errorf("worktree add: %w", err)
 	}
 	return nil
+}
+
+// WorktreeAddDetached creates a new git worktree in detached HEAD state.
+func WorktreeAddDetached(repoPath, worktreePath, commitish string) error {
+	_, err := RunGit(repoPath, "worktree", "add", "--detach", worktreePath, commitish)
+	if err != nil {
+		return fmt.Errorf("worktree add detached: %w", err)
+	}
+	return nil
+}
+
+// HeadSHA returns the full 40-character SHA of HEAD in the given directory.
+func HeadSHA(dir string) (string, error) {
+	out, err := RunGit(dir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("head sha: %w", err)
+	}
+	return out, nil
 }
 
 // WorktreeRemove removes a git worktree from the repository.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -255,6 +255,70 @@ func TestAvailableBranchName_DoubleCollision(t *testing.T) {
 	}
 }
 
+func TestWorktreeAdd_NoUpstreamTracking(t *testing.T) {
+	// Create an "upstream" repo and clone it so we have remote-tracking refs.
+	upstream := createTestRepo(t)
+	cloneDir := filepath.Join(t.TempDir(), "clone")
+	if _, err := git.RunGit(t.TempDir(), "clone", upstream, cloneDir); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	// Determine the default branch name in the clone
+	defaultBranch, err := git.CurrentBranch(cloneDir)
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+
+	// Create a worktree branching from origin/<default>
+	wtPath := filepath.Join(t.TempDir(), "wt-no-track")
+	base := "origin/" + defaultBranch
+	if err := git.WorktreeAdd(cloneDir, wtPath, base, "my-feature", true); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+
+	// Verify no upstream is set on the new branch
+	_, err = git.RunGit(cloneDir, "config", "branch.my-feature.remote")
+	if err == nil {
+		t.Fatal("expected branch.my-feature.remote to be unset, but it was configured")
+	}
+}
+
+func TestWorktreeAddDetached(t *testing.T) {
+	repo := createTestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "detached-wt")
+
+	if err := git.WorktreeAddDetached(repo, worktreePath, "HEAD"); err != nil {
+		t.Fatalf("WorktreeAddDetached: %v", err)
+	}
+
+	// Verify worktree directory was created
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree dir not created: %v", err)
+	}
+
+	// Verify it's in detached HEAD state
+	branch, err := git.CurrentBranch(worktreePath)
+	if err == nil {
+		t.Fatalf("expected detached HEAD error, got branch %q", branch)
+	}
+
+	// Clean up
+	if err := git.WorktreeRemove(repo, worktreePath); err != nil {
+		t.Fatalf("WorktreeRemove: %v", err)
+	}
+}
+
+func TestHeadSHA(t *testing.T) {
+	repo := createTestRepo(t)
+	sha, err := git.HeadSHA(repo)
+	if err != nil {
+		t.Fatalf("HeadSHA: %v", err)
+	}
+	if len(sha) != 40 {
+		t.Fatalf("expected 40-char SHA, got %q (len %d)", sha, len(sha))
+	}
+}
+
 func TestMinVersionCheck(t *testing.T) {
 	if err := git.MinVersionCheck(); err != nil {
 		t.Fatalf("MinVersionCheck: %v", err)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -58,6 +58,7 @@ type WorktreeRecord struct {
 	RepoPath     string `toml:"repo-path"`
 	WorktreePath string `toml:"worktree-path"`
 	Branch       string `toml:"branch"`
+	Commit       string `toml:"commit,omitempty"`
 }
 
 // WorktreeInfo is the runtime (dynamically discovered) view of a live worktree.


### PR DESCRIPTION
Allow creating worktrees in detached HEAD state, skipping branch creation entirely. This lets users decide later whether and what to name their branch.

- Add --detached flag to create and add-repo commands
- Add remote auto-fetch to add-repo (matching create behavior)
- Display "(detached)" in desc summary, short SHA in verbose output
- Archive captures HEAD SHA for detached worktrees before removal
- Restore recreates detached worktrees at the archived commit SHA
- Add Commit field to WorktreeRecord for detached archive/restore
- Fix make install to produce binary named "pj" instead of "projector"

This addresses some of the capabilities discussed in #2.