### PR TITLE
Change project open behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,12 @@ go test -v -race -count=1 ./internal/git/...
 
 | Package | Responsibility |
 |---|---|
-| `cmd/projector` | Cobra root + one file per subcommand (`projects.go`, `list.go`, `create.go`, `desc.go`, `open.go`, `path.go`, `addrepo.go`, `archive.go`, `restore.go`, `delete.go`, `version.go`, `config.go`, `config_run.go`, `config_list.go`, `config_get.go`, `config_set.go`). No business logic — delegate to internal packages. |
-| `internal/config` | `GlobalConfig` struct, `Load`/`Save`/`ResolveBase`/`Validate`. TOML I/O for `~/.projector/projector-config.toml`. |
+| `cmd/projector` | Cobra root + one file per subcommand (`projects.go`, `list.go`, `create.go`, `desc.go`, `open.go`, `path.go`, `addrepo.go`, `archive.go`, `restore.go`, `delete.go`, `version.go`, `config.go`, `config_run.go`, `config_list.go`, `config_get.go`, `config_set.go`, `config_unset.go`). No business logic — delegate to internal packages. |
+| `internal/config` | `GlobalConfig` struct, `EditorConfig` struct, `Load`/`Save`/`ResolveBase`/`Validate`. TOML I/O for `~/.projector/projector-config.toml`. |
 | `internal/project` | `ProjectConfig` struct, `Load`/`Save`/`ListAll`/`FindProjectDir`/`ValidateName`/`DiscoverWorktrees`. TOML I/O for `<projects-dir>/<name>/.projector.toml`. |
 | `internal/git` | Thin wrappers around the `git` executable: `RunGit`, `WorktreeAdd`, `WorktreeAddDetached`, `WorktreeRemove`, `WorktreeList`, `StatusPorcelain`, `RefExists`, `BranchExists`, `CurrentBranch`, `AvailableBranchName`, `Remotes`, `RemoteForRef`, `Fetch`, `HasUnpushedCommits`, `HeadSHA`, `MinVersionCheck`. |
 | `internal/repo` | `Repo` struct, `Discover` (non-recursive scan of search dirs), `ResolveRepos` (name or abs-path lookup). |
-| `internal/tui` | `SelectRepos` (huh multi-select), `SelectEditor` (huh single-select with installed/not-installed annotations), `ExpandHome` (tilde expansion). |
+| `internal/tui` | `SelectRepos` (huh multi-select), `SelectEditor` (huh single-select, installed editors only), `EditorOption` (with `Terminal` field), `ExpandHome` (tilde expansion). |
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,10 @@ $ pj project desc my-feature
 
 $ pj project open my-feature
 
-  Select an editor:
+  Choose an editor:
   > Cursor
     VS Code
     Zed
-
-  Opening my-feature in Cursor...
 ```
 
 ### First-time Setup
@@ -145,11 +143,23 @@ Set an individual configuration value.
 
 ```bash
 pj config set projects-dir ~/new-projects
-pj config set editor cursor
+pj config set default-editor cursor
 pj config set repo-search-dirs /path1,/path2            # replaces entire list
 pj config set --add repo-search-dirs /additional/path   # appends to list
 pj config set --remove repo-search-dirs /old/path       # removes from list
 pj config set repos.my-repo.default-base origin/develop
+pj config set editors.aider.command aider               # custom editor
+pj config set editors.aider.terminal true               # terminal-mode editor
+```
+
+#### `pj config unset <key>`
+
+Remove or clear an optional configuration value. Required keys (`projects-dir`, `repo-search-dirs`) cannot be unset.
+
+```bash
+pj config unset default-editor                   # clear default editor
+pj config unset editors.aider                     # remove a custom editor entry
+pj config unset repos.my-repo.default-base        # remove per-repo base override
 ```
 
 #### `pj version`
@@ -233,35 +243,73 @@ pj project create my-feature --detached --base origin/release-2.0
 
 #### `pj project open [project]`
 
-Open a project in your configured editor or IDE.
+Open a project in an editor or IDE.
 
 ```bash
 pj project open               # detect project from current directory
-pj project open my-feature
+pj project open my-feature    # prompts for editor each time
+pj project open my-feature -e cursor   # use specific editor, no prompt
 ```
 
-The first time this command is run (or when no editor is configured), an interactive prompt lets you choose from the supported options. Installed editors are annotated:
+By default, an interactive prompt shows all **installed** editors each time:
 
 ```
-? Choose a default editor for 'pj project open'
-  Cursor          (installed)
-  VS Code         (installed)
-  Zed             (not installed)
-  Sublime Text    (installed)
-  BBEdit          (not installed)
-  IntelliJ IDEA   (not installed)
-  Finder (macOS)  (installed)
+? Choose an editor
+> Cursor
+  VS Code
+  Windsurf
+  Zed
+  Claude Code
+  Finder (macOS)
 ```
 
-The choice is saved to `~/.projector/projector-config.toml`. You can change it there at any time, or set a completely custom command — any executable that accepts a directory path as its first positional argument works:
+To skip the prompt, set a default editor:
+
+```bash
+pj config set default-editor cursor
+```
+
+Or use the `-e` / `--editor` flag for one-off use:
+
+```bash
+pj project open my-feature -e code
+```
+
+**Terminal editors** — tools like Claude Code that run in the terminal print a `cd` + command instead of launching a GUI process:
+
+```
+$ pj project open my-feature -e claude
+To open in Claude Code, run:
+
+  cd /Users/alice/projects/my-feature && claude
+```
+
+**Custom editors** — define additional editors in the config file under `[editors.<name>]`:
 
 ```toml
-# editor: command used by "pj project open". Accepts any executable that takes
-# a directory path as its first positional argument (e.g. cursor, code, subl,
-# bbedit, idea, zed, finder). You can specify a custom command or script here
-# provided it follows the same convention.
-editor = "cursor"
+# default-editor: editor command used by "pj project open" without prompting.
+# When set, skips the interactive editor selection. Accepts any executable that
+# takes a directory path as its first argument (e.g. cursor, code, subl, zed).
+# Remove or leave empty to be prompted each time.
+default-editor = "cursor"
+
+[editors.myeditor]
+name = "My Custom Editor"
+command = "myedit"
+
+[editors.aider]
+name = "Aider"
+command = "aider"
+terminal = true
 ```
+
+Custom editors appear in the selection prompt if their command is found on PATH. Setting `terminal = true` causes `pj` to print a `cd` + command instead of launching.
+
+**CLI launcher setup** — some editors require setup to be launchable from the command line:
+
+- **IntelliJ IDEA**: Tools → Create Command-line Launcher (creates the `idea` command)
+- **VS Code**: install the `code` command from the Command Palette (Shell Command: Install)
+- **Cursor**: install the `cursor` command from the Command Palette
 
 #### `pj project path [project]`
 
@@ -436,7 +484,7 @@ projector/
     restore.go
     resolve.go       shared resolveProject helper
   internal/
-    config/          GlobalConfig, Load/Save/ResolveBase
+    config/          GlobalConfig, EditorConfig, Load/Save/ResolveBase
     project/         ProjectConfig, Load/Save/ListAll/DiscoverWorktrees
     git/             RunGit and all git wrappers
     repo/            Discover, ResolveRepos

--- a/cmd/projector/config.go
+++ b/cmd/projector/config.go
@@ -12,6 +12,7 @@ func newConfigCmd() *cobra.Command {
 		newConfigListCmd(),
 		newConfigGetCmd(),
 		newConfigSetCmd(),
+		newConfigUnsetCmd(),
 	)
 	return cmd
 }

--- a/cmd/projector/config_get.go
+++ b/cmd/projector/config_get.go
@@ -16,10 +16,13 @@ func newConfigGetCmd() *cobra.Command {
 		Long: `Get an individual configuration value.
 
 Supported keys:
-  projects-dir                   Path where project directories are created
-  repo-search-dirs               Comma-separated list of repo search directories
-  editor                         Editor command for 'pj project open'
-  repos.<name>.default-base      Per-repo default branch base`,
+  projects-dir                     Path where project directories are created
+  repo-search-dirs                 Comma-separated list of repo search directories
+  default-editor                   Default editor command for 'pj project open'
+  editors.<name>.name              Display name for a custom editor
+  editors.<name>.command           Executable command for a custom editor
+  editors.<name>.terminal          Whether editor is terminal-mode ("true"/"false")
+  repos.<name>.default-base        Per-repo default branch base`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := args[0]
@@ -39,8 +42,34 @@ Supported keys:
 			case key == "repo-search-dirs":
 				fmt.Println(strings.Join(cfg.RepoSearchDirs, ","))
 
-			case key == "editor":
-				fmt.Println(cfg.Editor)
+			case key == "default-editor":
+				fmt.Println(cfg.DefaultEditor)
+
+			case strings.HasPrefix(key, "editors."):
+				trimmed := strings.TrimPrefix(key, "editors.")
+				parts := strings.SplitN(trimmed, ".", 2)
+				if len(parts) != 2 || parts[0] == "" {
+					return fmt.Errorf("invalid key %q; expected editors.<name>.<field>", key)
+				}
+				editorName := parts[0]
+				field := parts[1]
+				if cfg.Editors == nil {
+					return nil
+				}
+				ec, ok := cfg.Editors[editorName]
+				if !ok {
+					return nil
+				}
+				switch field {
+				case "name":
+					fmt.Println(ec.Name)
+				case "command":
+					fmt.Println(ec.Command)
+				case "terminal":
+					fmt.Println(ec.Terminal)
+				default:
+					return fmt.Errorf("unknown editor field %q; valid fields: name, command, terminal", field)
+				}
 
 			case strings.HasPrefix(key, "repos.") && strings.HasSuffix(key, ".default-base"):
 				trimmed := strings.TrimPrefix(key, "repos.")
@@ -58,7 +87,7 @@ Supported keys:
 				fmt.Println(repoCfg.DefaultBase)
 
 			default:
-				return fmt.Errorf("unknown key %q; valid keys: projects-dir, repo-search-dirs, editor, repos.<name>.default-base", key)
+				return fmt.Errorf("unknown key %q; valid keys: projects-dir, repo-search-dirs, default-editor, editors.<name>.<field>, repos.<name>.default-base", key)
 			}
 
 			return nil

--- a/cmd/projector/config_list.go
+++ b/cmd/projector/config_list.go
@@ -31,8 +31,29 @@ func newConfigListCmd() *cobra.Command {
 				fmt.Printf("repo-search-dirs.%d=%s\n", i, dir)
 			}
 
-			if cfg.Editor != "" {
-				fmt.Printf("editor=%s\n", cfg.Editor)
+			if cfg.DefaultEditor != "" {
+				fmt.Printf("default-editor=%s\n", cfg.DefaultEditor)
+			}
+
+			if len(cfg.Editors) > 0 {
+				editorNames := make([]string, 0, len(cfg.Editors))
+				for name := range cfg.Editors {
+					editorNames = append(editorNames, name)
+				}
+				sort.Strings(editorNames)
+
+				for _, name := range editorNames {
+					ec := cfg.Editors[name]
+					if ec.Name != "" {
+						fmt.Printf("editors.%s.name=%s\n", name, ec.Name)
+					}
+					if ec.Command != "" {
+						fmt.Printf("editors.%s.command=%s\n", name, ec.Command)
+					}
+					if ec.Terminal {
+						fmt.Printf("editors.%s.terminal=true\n", name)
+					}
+				}
 			}
 
 			if len(cfg.Repos) > 0 {

--- a/cmd/projector/config_run.go
+++ b/cmd/projector/config_run.go
@@ -84,7 +84,8 @@ func runConfigWizard() error {
 
 	// Preserve existing fields not covered by the wizard.
 	if existing != nil {
-		cfg.Editor = existing.Editor
+		cfg.DefaultEditor = existing.DefaultEditor
+		cfg.Editors = existing.Editors
 		cfg.Repos = existing.Repos
 	}
 

--- a/cmd/projector/config_set.go
+++ b/cmd/projector/config_set.go
@@ -22,10 +22,13 @@ func newConfigSetCmd() *cobra.Command {
 		Long: `Set an individual configuration key-value pair.
 
 Supported keys:
-  projects-dir                   Path where project directories are created
-  repo-search-dirs               Comma-separated list of repo search directories
-  editor                         Editor command for 'pj project open'
-  repos.<name>.default-base      Per-repo default branch base
+  projects-dir                     Path where project directories are created
+  repo-search-dirs                 Comma-separated list of repo search directories
+  default-editor                   Default editor command for 'pj project open'
+  editors.<name>.name              Display name for a custom editor
+  editors.<name>.command           Executable command for a custom editor
+  editors.<name>.terminal          "true"/"false" — print cd+command instead of launching
+  repos.<name>.default-base        Per-repo default branch base
 
 Flags --add and --remove can be used with repo-search-dirs to append or remove
 a single entry instead of replacing the entire list.`,
@@ -88,9 +91,35 @@ a single entry instead of replacing the entire list.`,
 					fmt.Printf("Set repo-search-dirs = %s\n", strings.Join(dirs, ", "))
 				}
 
-			case key == "editor":
-				cfg.Editor = value
-				fmt.Printf("Set editor = %s\n", cfg.Editor)
+			case key == "default-editor":
+				cfg.DefaultEditor = value
+				fmt.Printf("Set default-editor = %s\n", cfg.DefaultEditor)
+
+			case strings.HasPrefix(key, "editors."):
+				// editors.<name>.name, editors.<name>.command, editors.<name>.terminal
+				trimmed := strings.TrimPrefix(key, "editors.")
+				parts := strings.SplitN(trimmed, ".", 2)
+				if len(parts) != 2 || parts[0] == "" {
+					return fmt.Errorf("invalid key %q; expected editors.<name>.<field>", key)
+				}
+				editorName := parts[0]
+				field := parts[1]
+				if cfg.Editors == nil {
+					cfg.Editors = make(map[string]config.EditorConfig)
+				}
+				ec := cfg.Editors[editorName]
+				switch field {
+				case "name":
+					ec.Name = value
+				case "command":
+					ec.Command = value
+				case "terminal":
+					ec.Terminal = value == "true"
+				default:
+					return fmt.Errorf("unknown editor field %q; valid fields: name, command, terminal", field)
+				}
+				cfg.Editors[editorName] = ec
+				fmt.Printf("Set %s = %s\n", key, value)
 
 			case strings.HasPrefix(key, "repos.") && strings.HasSuffix(key, ".default-base"):
 				// Extract repo name from repos.<name>.default-base
@@ -106,7 +135,7 @@ a single entry instead of replacing the entire list.`,
 				fmt.Printf("Set repos.%s.default-base = %s\n", trimmed, value)
 
 			default:
-				return fmt.Errorf("unknown key %q; valid keys: projects-dir, repo-search-dirs, editor, repos.<name>.default-base", key)
+				return fmt.Errorf("unknown key %q; valid keys: projects-dir, repo-search-dirs, default-editor, editors.<name>.<field>, repos.<name>.default-base", key)
 			}
 
 			if err := config.Save(cfg); err != nil {

--- a/cmd/projector/config_unset.go
+++ b/cmd/projector/config_unset.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kevdoran/projector/internal/config"
+)
+
+func newConfigUnsetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unset <key>",
+		Short: "Unset (clear) an optional config value",
+		Long: `Remove or clear an optional configuration value.
+
+Unsettable keys:
+  default-editor                   Clear the default editor setting
+  editors.<name>                   Remove an entire custom editor entry
+  repos.<name>.default-base        Remove a per-repo default base override
+
+Required keys (cannot be unset):
+  projects-dir
+  repo-search-dirs`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+
+			cfg, err := config.Load()
+			if err != nil {
+				if err == config.ErrNotFound {
+					return fmt.Errorf("no configuration found; run 'pj config setup' to set up pj")
+				}
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			switch {
+			case key == "projects-dir", key == "repo-search-dirs":
+				return fmt.Errorf("cannot unset required key %q", key)
+
+			case key == "default-editor":
+				cfg.DefaultEditor = ""
+
+			case strings.HasPrefix(key, "editors."):
+				editorName := strings.TrimPrefix(key, "editors.")
+				// Reject sub-field keys like editors.<name>.command — unset removes the whole entry
+				if editorName == "" || strings.Contains(editorName, ".") {
+					return fmt.Errorf("invalid key %q; use editors.<name> to remove an entire editor entry", key)
+				}
+				if cfg.Editors == nil {
+					return fmt.Errorf("editor %q not found", editorName)
+				}
+				if _, ok := cfg.Editors[editorName]; !ok {
+					return fmt.Errorf("editor %q not found", editorName)
+				}
+				delete(cfg.Editors, editorName)
+
+			case strings.HasPrefix(key, "repos.") && strings.HasSuffix(key, ".default-base"):
+				repoName := strings.TrimPrefix(key, "repos.")
+				repoName = strings.TrimSuffix(repoName, ".default-base")
+				if repoName == "" || strings.Contains(repoName, ".") {
+					return fmt.Errorf("invalid key %q; expected repos.<name>.default-base", key)
+				}
+				if cfg.Repos == nil {
+					return fmt.Errorf("repo %q not found", repoName)
+				}
+				if _, ok := cfg.Repos[repoName]; !ok {
+					return fmt.Errorf("repo %q not found", repoName)
+				}
+				delete(cfg.Repos, repoName)
+
+			default:
+				return fmt.Errorf("unknown or non-unsettable key %q; unsettable keys: default-editor, editors.<name>, repos.<name>.default-base", key)
+			}
+
+			if err := config.Save(cfg); err != nil {
+				return fmt.Errorf("save config: %w", err)
+			}
+
+			fmt.Printf("Unset %s\n", key)
+			return nil
+		},
+	}
+}

--- a/cmd/projector/open.go
+++ b/cmd/projector/open.go
@@ -12,23 +12,36 @@ import (
 	"github.com/kevdoran/projector/internal/tui"
 )
 
-// supportedEditors is the ordered list of editors offered in the selection prompt.
+// builtinEditors is the ordered list of editors offered in the selection prompt.
 // Each entry must accept a directory path as its first positional argument.
 // "finder" is a special case handled by `open /path` on macOS.
-var supportedEditors = []tui.EditorOption{
+var builtinEditors = []tui.EditorOption{
 	{Name: "Cursor", Command: "cursor"},
 	{Name: "VS Code", Command: "code"},
+	{Name: "Windsurf", Command: "windsurf"},
 	{Name: "Zed", Command: "zed"},
 	{Name: "Sublime Text", Command: "subl"},
 	{Name: "BBEdit", Command: "bbedit"},
 	{Name: "IntelliJ IDEA", Command: "idea"},
+	{Name: "Claude Code", Command: "claude", Terminal: true},
+	{Name: "OpenCode", Command: "opencode", Terminal: true},
 	{Name: "Finder (macOS)", Command: "finder"},
 }
 
 func newOpenCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "open [project]",
-		Short: "Open a project in the configured editor or IDE",
+	var editorFlag string
+
+	cmd := &cobra.Command{
+		Use:   "open [project] [-e editor]",
+		Short: "Open a project in an editor or IDE",
+		Long: `Open a project in an editor or IDE.
+
+If no project is specified, the current directory is used to resolve the project.
+Prompts for an editor unless --editor/-e is given or default-editor is set in config.
+
+To always open with a specific editor without being prompted:
+  pj config set default-editor <command>    (e.g. cursor, code, claude)
+  pj config unset default-editor            (restore the prompt)`,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadConfig()
@@ -41,11 +54,23 @@ func newOpenCmd() *cobra.Command {
 				return err
 			}
 
-			// First run: no editor configured — prompt the user.
-			if cfg.Editor == "" {
-				fmt.Println("No default editor configured for 'pj project open'.")
-				options := detectEditors()
-				choice, err := tui.SelectEditor(options)
+			// Build the full editor list (builtins + custom config entries).
+			allEditors := buildEditorList(cfg)
+
+			// Determine which editor to use.
+			var editorCmd string
+			switch {
+			case editorFlag != "":
+				editorCmd = editorFlag
+			case cfg.DefaultEditor != "":
+				editorCmd = cfg.DefaultEditor
+			default:
+				// Interactive selection — only show installed editors.
+				installed := filterInstalled(allEditors)
+				if len(installed) == 0 {
+					return fmt.Errorf("no supported editors found on PATH; use --editor to specify one")
+				}
+				choice, err := tui.SelectEditor(installed)
 				if err != nil {
 					if errors.Is(err, tui.ErrAborted) {
 						fmt.Println("Aborted.")
@@ -53,46 +78,103 @@ func newOpenCmd() *cobra.Command {
 					}
 					return fmt.Errorf("select editor: %w", err)
 				}
-				cfg.Editor = choice
-				if err := config.Save(cfg); err != nil {
-					return fmt.Errorf("save config: %w", err)
-				}
-				fmt.Printf("Default editor set to %q. You can change it in ~/.projector/projector-config.toml\n", cfg.Editor)
+				editorCmd = choice
 			}
 
-			return launchEditor(cfg.Editor, projectDir)
+			// Look up editor metadata for terminal mode.
+			editorMeta := findEditor(allEditors, editorCmd)
+			if err := launchEditor(editorMeta, projectDir); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&editorFlag, "editor", "e", "", "editor command to use (skips prompt)")
+
+	return cmd
 }
 
-// detectEditors annotates supportedEditors with installation status.
-func detectEditors() []tui.EditorOption {
-	options := make([]tui.EditorOption, len(supportedEditors))
-	for i, e := range supportedEditors {
-		options[i] = e
-		if e.Command == "finder" {
-			// Finder is always available on macOS.
-			options[i].Installed = true
+// buildEditorList merges builtinEditors with custom editors from config.
+// Config entries override builtins by command key.
+func buildEditorList(cfg *config.GlobalConfig) []tui.EditorOption {
+	// Start with builtins; config entries can override by command.
+	byCommand := make(map[string]int, len(builtinEditors))
+	result := make([]tui.EditorOption, len(builtinEditors))
+	copy(result, builtinEditors)
+	for i, e := range result {
+		byCommand[e.Command] = i
+	}
+
+	for key, ec := range cfg.Editors {
+		command := ec.Command
+		if command == "" {
+			command = key
+		}
+		name := ec.Name
+		if name == "" {
+			name = key
+		}
+		opt := tui.EditorOption{
+			Name:     name,
+			Command:  command,
+			Terminal: ec.Terminal,
+		}
+		if idx, ok := byCommand[command]; ok {
+			// Override the builtin.
+			result[idx] = opt
 		} else {
-			_, err := exec.LookPath(e.Command)
-			options[i].Installed = err == nil
+			byCommand[command] = len(result)
+			result = append(result, opt)
 		}
 	}
-	return options
+
+	return result
 }
 
-// launchEditor opens projectDir in the configured editor.
-func launchEditor(editorCmd, projectDir string) error {
+// filterInstalled returns only the editors whose commands are found on PATH.
+func filterInstalled(editors []tui.EditorOption) []tui.EditorOption {
+	var installed []tui.EditorOption
+	for _, e := range editors {
+		if e.Command == "finder" {
+			// Finder is always available on macOS.
+			installed = append(installed, e)
+		} else if _, err := exec.LookPath(e.Command); err == nil {
+			installed = append(installed, e)
+		}
+	}
+	return installed
+}
+
+// findEditor looks up an editor by command in the list. If not found, returns
+// a default EditorOption with the given command.
+func findEditor(editors []tui.EditorOption, command string) tui.EditorOption {
+	for _, e := range editors {
+		if e.Command == command {
+			return e
+		}
+	}
+	return tui.EditorOption{Name: command, Command: command}
+}
+
+// launchEditor opens projectDir in the specified editor.
+func launchEditor(editor tui.EditorOption, projectDir string) error {
+	if editor.Terminal {
+		fmt.Printf("To open in %s, run:\n\n  cd %s && %s\n", editor.Name, projectDir, editor.Command)
+		return nil
+	}
+
 	var cmd *exec.Cmd
-	if editorCmd == "finder" {
+	if editor.Command == "finder" {
 		cmd = exec.Command("open", projectDir)
 	} else {
-		cmd = exec.Command(editorCmd, projectDir)
+		cmd = exec.Command(editor.Command, projectDir)
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("launch %q: %w", editorCmd, err)
+		return fmt.Errorf("launch %q: %w", editor.Command, err)
 	}
 	// Don't wait — GUI apps return immediately from Start and run independently.
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,11 +30,19 @@ var ErrConfigVersionTooNew = errors.New("config file was written by a newer vers
 
 // GlobalConfig is the top-level structure for ~/.projector/projector-config.toml.
 type GlobalConfig struct {
-	ConfigVersion  int                   `toml:"config-version"`
-	ProjectsDir    string                `toml:"projects-dir"`
-	RepoSearchDirs []string              `toml:"repo-search-dirs"`
-	Editor         string                `toml:"editor,omitempty"`
-	Repos          map[string]RepoConfig `toml:"repos"`
+	ConfigVersion  int                      `toml:"config-version"`
+	ProjectsDir    string                   `toml:"projects-dir"`
+	RepoSearchDirs []string                 `toml:"repo-search-dirs"`
+	DefaultEditor  string                   `toml:"default-editor,omitempty"`
+	Editors        map[string]EditorConfig  `toml:"editors,omitempty"`
+	Repos          map[string]RepoConfig    `toml:"repos"`
+}
+
+// EditorConfig holds custom editor definitions stored under [editors.<name>].
+type EditorConfig struct {
+	Name     string `toml:"name,omitempty"`     // display name (defaults to key)
+	Command  string `toml:"command,omitempty"`   // executable (defaults to key)
+	Terminal bool   `toml:"terminal,omitempty"`  // if true, print cd+command instead of launching
 }
 
 // RepoConfig holds per-repository overrides stored under [repos.<name>].
@@ -83,14 +91,14 @@ func Load() (*GlobalConfig, error) {
 	return cfg, nil
 }
 
-const editorComment = `# editor: command used by "pj project open". Accepts any executable that takes
-# a directory path as its first positional argument (e.g. cursor, code, subl,
-# bbedit, idea, zed, finder). You can specify a custom command or script here
-# provided it follows the same convention.
+const editorComment = `# default-editor: editor command used by "pj project open" without prompting.
+# When set, skips the interactive editor selection. Accepts any executable that
+# takes a directory path as its first argument (e.g. cursor, code, subl, zed).
+# Remove or leave empty to be prompted each time.
 `
 
 // Save writes the config to disk, creating the config directory if needed.
-// When the editor field is set, an explanatory comment is inserted above it.
+// When the default-editor field is set, an explanatory comment is inserted above it.
 func Save(cfg *GlobalConfig) error {
 	path, err := ConfigFilePath()
 	if err != nil {
@@ -110,8 +118,8 @@ func Save(cfg *GlobalConfig) error {
 	}
 
 	content := buf.String()
-	if cfg.Editor != "" {
-		content = strings.Replace(content, "editor = ", editorComment+"editor = ", 1)
+	if cfg.DefaultEditor != "" {
+		content = strings.Replace(content, "default-editor = ", editorComment+"default-editor = ", 1)
 	}
 
 	f, err := os.Create(path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,10 @@ func TestSave_And_Load_RoundTrip(t *testing.T) {
 	cfg := &config.GlobalConfig{
 		ProjectsDir:    "/tmp/projects",
 		RepoSearchDirs: []string{"/tmp/repos1", "/tmp/repos2"},
+		DefaultEditor:  "cursor",
+		Editors: map[string]config.EditorConfig{
+			"myeditor": {Name: "My Editor", Command: "myedit", Terminal: true},
+		},
 		Repos: map[string]config.RepoConfig{
 			"my-repo": {DefaultBase: "origin/develop"},
 		},
@@ -51,11 +55,50 @@ func TestSave_And_Load_RoundTrip(t *testing.T) {
 	if len(loaded.RepoSearchDirs) != 2 {
 		t.Errorf("RepoSearchDirs len: got %d, want 2", len(loaded.RepoSearchDirs))
 	}
+	if loaded.DefaultEditor != "cursor" {
+		t.Errorf("DefaultEditor: got %q, want %q", loaded.DefaultEditor, "cursor")
+	}
+	if loaded.Editors["myeditor"].Name != "My Editor" {
+		t.Errorf("Editors[myeditor].Name: got %q", loaded.Editors["myeditor"].Name)
+	}
+	if loaded.Editors["myeditor"].Command != "myedit" {
+		t.Errorf("Editors[myeditor].Command: got %q", loaded.Editors["myeditor"].Command)
+	}
+	if !loaded.Editors["myeditor"].Terminal {
+		t.Error("Editors[myeditor].Terminal: got false, want true")
+	}
 	if loaded.Repos["my-repo"].DefaultBase != "origin/develop" {
 		t.Errorf("Repos[my-repo].DefaultBase: got %q", loaded.Repos["my-repo"].DefaultBase)
 	}
 	if loaded.ConfigVersion != config.CurrentConfigVersion {
 		t.Errorf("ConfigVersion: got %d, want %d", loaded.ConfigVersion, config.CurrentConfigVersion)
+	}
+}
+
+func TestLoad_IgnoresOldEditorField(t *testing.T) {
+	home := withTempHome(t)
+	cfgDir := filepath.Join(home, ".projector")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an old config file with the deprecated "editor" field.
+	content := `config-version = 1
+projects-dir = "/tmp/projects"
+editor = "code"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "projector-config.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// The old editor field should be silently ignored; DefaultEditor should be empty.
+	if loaded.DefaultEditor != "" {
+		t.Errorf("DefaultEditor should be empty for old config, got %q", loaded.DefaultEditor)
+	}
+	if loaded.ProjectsDir != "/tmp/projects" {
+		t.Errorf("ProjectsDir: got %q", loaded.ProjectsDir)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -75,22 +75,21 @@ func SelectRepos(available []repo.Repo, exclude []string) ([]repo.Repo, error) {
 
 // EditorOption represents a selectable editor in the SelectEditor prompt.
 type EditorOption struct {
-	Name      string // display name, e.g. "Cursor"
-	Command   string // value stored in config, e.g. "cursor"
-	Installed bool   // whether the command was detected on PATH
+	Name     string // display name, e.g. "Cursor"
+	Command  string // value stored in config, e.g. "cursor"
+	Terminal bool   // if true, print cd+command instead of launching
 }
 
-// SelectEditor presents an interactive single-select prompt for choosing a default editor.
+// SelectEditor presents an interactive single-select prompt for choosing an editor.
+// Only editors that are available should be passed in (no install annotations).
 func SelectEditor(options []EditorOption) (string, error) {
+	if len(options) == 0 {
+		return "", fmt.Errorf("no editors available")
+	}
+
 	var huhOptions []huh.Option[string]
 	for _, o := range options {
-		label := o.Name
-		if o.Installed {
-			label += "  (installed)"
-		} else {
-			label += "  (not installed)"
-		}
-		huhOptions = append(huhOptions, huh.NewOption(label, o.Command))
+		huhOptions = append(huhOptions, huh.NewOption(o.Name, o.Command))
 	}
 
 	km := huh.NewDefaultKeyMap()
@@ -100,7 +99,7 @@ func SelectEditor(options []EditorOption) (string, error) {
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
-				Title("Choose a default editor for 'pj project open'").
+				Title("Choose an editor").
 				Description("Select with arrow keys, confirm with enter, esc to abort").
 				Options(huhOptions...).
 				Value(&selected),


### PR DESCRIPTION
## Summary

- **Prompt every time** instead of persisting the editor choice — `pj project open` now shows an interactive selector on each run (only installed editors shown), unless `--editor`/`-e` flag or `default-editor` config is set
- **Add `--editor`/`-e` flag** for one-off editor selection without being prompted
- **Rename `editor` config key to `default-editor`** — old config files with `editor` are silently ignored (no migration needed; users re-set via `pj config set default-editor <cmd>`)
- **Add terminal editor support** — editors like Claude Code and OpenCode that run in the terminal print `cd <dir> && <command>` instead of launching a GUI process
- **Add builtin editors**: Windsurf, Claude Code, OpenCode
- **Add custom editor config** — users can define additional editors under `[editors.<name>]` in the config file with `name`, `command`, and `terminal` fields
- **Add `pj config unset` command** — clears optional config keys (`default-editor`, `editors.<name>`, `repos.<name>.default-base`); refuses to unset required keys
- **Extend `config get`, `config set`, `config list`** to support the new `default-editor` and `editors.<name>.<field>` keys

## Files changed

| File | Change |
|---|---|
| `cmd/projector/open.go` | Reworked open command: prompt-every-time, `-e` flag, terminal editor handling, builtin editor list with Windsurf/Claude Code/OpenCode, `buildEditorList`/`filterInstalled`/`findEditor` helpers |
| `cmd/projector/config_unset.go` | New `pj config unset` subcommand |
| `cmd/projector/config.go` | Wire up `config unset` subcommand |
| `cmd/projector/config_get.go` | Support `default-editor` and `editors.<name>.<field>` keys |
| `cmd/projector/config_set.go` | Support `default-editor` and `editors.<name>.<field>` keys |
| `cmd/projector/config_list.go` | Display `default-editor` and `editors.*` entries |
| `cmd/projector/config_run.go` | Preserve `DefaultEditor` and `Editors` when re-running wizard |
| `internal/config/config.go` | Rename `Editor` → `DefaultEditor`, add `EditorConfig` struct and `Editors` map, update Save comment logic |
| `internal/config/config_test.go` | Round-trip test for `DefaultEditor`/`Editors`, test that old `editor` field is silently ignored |
| `internal/tui/tui.go` | Replace `Installed` field with `Terminal` on `EditorOption`, simplify `SelectEditor` to show only available editors without install annotations |
| `README.md` | Updated docs for open command, editor config, `config unset`, custom editors |
| `CLAUDE.md` | Updated package table for new files and structs |

## Test plan

- [ ] `make build && make vet && make test` passes
- [ ] `pj project open` prompts for editor (only installed ones shown)
- [ ] `pj project open -e cursor` opens directly without prompt
- [ ] `pj config set default-editor cursor` → `pj project open` skips prompt
- [ ] `pj config unset default-editor` → prompt returns
- [ ] `pj project open -e claude` prints `cd ... && claude` (terminal mode)
- [ ] `pj config set editors.aider.command aider && pj config set editors.aider.terminal true` → aider appears in prompt
- [ ] `pj config unset editors.aider` removes custom editor
- [ ] Old config files with `editor = "code"` load without error (field silently ignored)