### PR TITLE
Add preview and progress output to project delete and archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,26 @@ pj project delete my-feature --delete-branches   # also delete git branches
 pj project delete my-feature --yes               # skip confirmation prompt
 ```
 
-A confirmation prompt is shown before any destructive action. Pass `-y` / `--yes` to skip it (useful in scripts).
+Before proceeding, the command previews the exact git commands it will run and suggests alternatives:
+
+```
+The following actions will be performed:
+
+  api:
+    git worktree remove /Users/alice/projects/my-feature/api+my-feature
+  frontend:
+    git worktree remove /Users/alice/projects/my-feature/frontend+my-feature
+
+  rm -rf /Users/alice/projects/my-feature
+
+Alternatives:
+  - To archive (reversible): pj project archive my-feature
+  - To clean up manually, remove the worktrees and directory listed above
+
+Proceed? [y/N]:
+```
+
+With `--delete-branches`, the preview also shows the branch deletion commands. Pass `-y` / `--yes` to skip the preview and prompt (useful in scripts); progress output still prints.
 
 **Safety checks** — the following will cause the command to refuse:
 - Any worktree has uncommitted changes or untracked files

--- a/cmd/projector/archive.go
+++ b/cmd/projector/archive.go
@@ -72,6 +72,7 @@ func newArchiveCmd() *cobra.Command {
 			var removeErr error
 
 			for _, wt := range worktrees {
+				fmt.Printf("  Removing worktree for %s (this may take a while)...\n", wt.RepoName)
 				if err := git.WorktreeRemove(wt.RepoPath, wt.WorktreePath); err != nil {
 					removeErr = fmt.Errorf("remove worktree %s: %w", wt.RepoName, err)
 					break
@@ -81,7 +82,6 @@ func newArchiveCmd() *cobra.Command {
 					break
 				}
 				removed = append(removed, removedWorktree{wt})
-				fmt.Printf("  removed worktree: %s\n", wt.WorktreePath)
 			}
 
 			if removeErr != nil {

--- a/cmd/projector/delete.go
+++ b/cmd/projector/delete.go
@@ -119,14 +119,43 @@ func newDeleteCmd() *cobra.Command {
 				}
 			}
 
-			// Confirmation prompt.
+			// Confirmation prompt with preview of actions.
 			if !yes {
-				fmt.Fprintf(os.Stderr, "About to permanently delete project %q (%d worktree(s))", p.Project.Name, len(worktrees))
-				if deleteBranches {
-					fmt.Fprintf(os.Stderr, " and delete its branches")
+				fmt.Fprintln(os.Stderr, "The following actions will be performed:")
+				fmt.Fprintln(os.Stderr)
+				if len(worktrees) == 0 {
+					fmt.Fprintln(os.Stderr, "  (no git worktrees to clean up)")
+				} else {
+					for _, wt := range worktrees {
+						fmt.Fprintf(os.Stderr, "  %s:\n", wt.repoName)
+						hasAction := false
+						if p.Project.Status == project.StatusActive {
+							fmt.Fprintf(os.Stderr, "    git worktree remove %s\n", wt.worktreePath)
+							hasAction = true
+						}
+						if deleteBranches {
+							fmt.Fprintf(os.Stderr, "    git branch -D %s  (in %s)\n", wt.branch, wt.repoPath)
+							hasAction = true
+						}
+						if !hasAction {
+							fmt.Fprintln(os.Stderr, "    (nothing to do)")
+						}
+					}
 				}
-				fmt.Fprintln(os.Stderr, ".")
-				fmt.Fprint(os.Stderr, "This cannot be undone. Proceed? [y/N]: ")
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintf(os.Stderr, "  rm -rf %s\n", projectDir)
+				fmt.Fprintln(os.Stderr)
+
+				fmt.Fprintln(os.Stderr, "Alternatives:")
+				fmt.Fprintf(os.Stderr, "  - To archive (reversible): pj project archive %s\n", p.Project.Name)
+				if deleteBranches {
+					fmt.Fprintln(os.Stderr, "  - To clean up manually, remove the worktrees and branches listed above")
+				} else {
+					fmt.Fprintln(os.Stderr, "  - To clean up manually, remove the worktrees and directory listed above")
+				}
+				fmt.Fprintln(os.Stderr)
+
+				fmt.Fprint(os.Stderr, "Proceed? [y/N]: ")
 				reader := bufio.NewReader(os.Stdin)
 				response, _ := reader.ReadString('\n')
 				if strings.ToLower(strings.TrimSpace(response)) != "y" {
@@ -138,6 +167,7 @@ func newDeleteCmd() *cobra.Command {
 			// Execute.
 			if p.Project.Status == project.StatusActive {
 				for _, wt := range worktrees {
+					fmt.Printf("  Removing worktree for %s (this may take a while)...\n", wt.repoName)
 					if err := git.WorktreeRemove(wt.repoPath, wt.worktreePath); err != nil {
 						return fmt.Errorf("remove worktree for %s: %w", wt.repoName, err)
 					}
@@ -146,13 +176,14 @@ func newDeleteCmd() *cobra.Command {
 
 			if deleteBranches {
 				for _, wt := range worktrees {
+					fmt.Printf("  Deleting branch %q in %s...\n", wt.branch, wt.repoName)
 					if _, err := git.RunGit(wt.repoPath, "branch", "-D", wt.branch); err != nil {
 						return fmt.Errorf("delete branch %q in %s: %w", wt.branch, wt.repoName, err)
 					}
-					fmt.Printf("  deleted branch %q in %s\n", wt.branch, wt.repoName)
 				}
 			}
 
+			fmt.Printf("  Removing project directory...\n")
 			if err := os.RemoveAll(projectDir); err != nil {
 				return fmt.Errorf("remove project dir: %w", err)
 			}


### PR DESCRIPTION
Show the exact git commands that will be run in the delete confirmation prompt, suggest alternatives (archive, manual cleanup), and print per-repo progress during execution.

Also add progress output to the archive command for consistency.