### PR TITLE
Fix bugs found in release candidate testing

### DIFF
--- a/cmd/projector/addrepo.go
+++ b/cmd/projector/addrepo.go
@@ -278,35 +278,56 @@ func newAddRepoCmd() *cobra.Command {
 				}
 			}
 
-			// Phase 3: Create worktrees.
+			// Phase 3: Create worktrees, tracking for rollback on failure.
+			var created []struct {
+				repoPath     string
+				worktreePath string
+			}
+			rollback := func() {
+				for i := len(created) - 1; i >= 0; i-- {
+					c := created[i]
+					_ = git.WorktreeRemove(c.repoPath, c.worktreePath)
+					_ = os.RemoveAll(c.worktreePath)
+				}
+			}
+
 			for _, rr := range resolved {
 				worktreePath := filepath.Join(projectDir, rr.repo.Name+"+"+projectName)
 
 				if detached {
 					if err := git.WorktreeAddDetached(rr.repo.Path, worktreePath, rr.base); err != nil {
+						rollback()
 						return fmt.Errorf("add worktree for %s: %w", rr.repo.Name, err)
 					}
 					fmt.Printf("  added worktree: %s (detached at %s)\n", worktreePath, rr.base)
 				} else if checkout {
 					branchName, err := git.BranchNameFromRef(rr.repo.Path, rr.base)
 					if err != nil {
+						rollback()
 						return fmt.Errorf("resolve branch name for %s: %w", rr.repo.Name, err)
 					}
 					if err := git.WorktreeAdd(rr.repo.Path, worktreePath, "", branchName, false); err != nil {
+						rollback()
 						return fmt.Errorf("add worktree for %s: %w", rr.repo.Name, err)
 					}
 					fmt.Printf("  added worktree: %s (checkout: %s)\n", worktreePath, branchName)
 				} else {
 					branchName, err := git.AvailableBranchName(rr.repo.Path, projectName, now)
 					if err != nil {
+						rollback()
 						return fmt.Errorf("branch name for %s: %w", rr.repo.Name, err)
 					}
 
 					if err := git.WorktreeAdd(rr.repo.Path, worktreePath, rr.base, branchName, true); err != nil {
+						rollback()
 						return fmt.Errorf("add worktree for %s: %w", rr.repo.Name, err)
 					}
 					fmt.Printf("  added worktree: %s (branch: %s)\n", worktreePath, branchName)
 				}
+				created = append(created, struct {
+					repoPath     string
+					worktreePath string
+				}{rr.repo.Path, worktreePath})
 			}
 
 			return nil

--- a/cmd/projector/archive.go
+++ b/cmd/projector/archive.go
@@ -93,9 +93,20 @@ func newArchiveCmd() *cobra.Command {
 				var rollbackFailed []string
 				for _, r := range removed {
 					wt := r.wt
-					if err := git.WorktreeAdd(wt.RepoPath, wt.WorktreePath, "", wt.Branch, false); err != nil {
+					var rollbackErr error
+					if wt.Branch == "" {
+						// Detached worktree: restore at the captured HEAD SHA.
+						commitish := detachedSHAs[wt.WorktreePath]
+						if commitish == "" {
+							commitish = "HEAD"
+						}
+						rollbackErr = git.WorktreeAddDetached(wt.RepoPath, wt.WorktreePath, commitish)
+					} else {
+						rollbackErr = git.WorktreeAdd(wt.RepoPath, wt.WorktreePath, "", wt.Branch, false)
+					}
+					if rollbackErr != nil {
 						rollbackFailed = append(rollbackFailed, wt.RepoName)
-						fmt.Fprintf(os.Stderr, "  rollback failed for %s: %v\n", wt.RepoName, err)
+						fmt.Fprintf(os.Stderr, "  rollback failed for %s: %v\n", wt.RepoName, rollbackErr)
 					} else {
 						fmt.Fprintf(os.Stderr, "  restored: %s\n", wt.RepoName)
 					}

--- a/cmd/projector/config_set.go
+++ b/cmd/projector/config_set.go
@@ -115,7 +115,14 @@ a single entry instead of replacing the entire list.`,
 				case "command":
 					ec.Command = value
 				case "terminal":
-					ec.Terminal = value == "true"
+					switch value {
+					case "true":
+						ec.Terminal = true
+					case "false":
+						ec.Terminal = false
+					default:
+						return fmt.Errorf("invalid value %q for terminal; must be \"true\" or \"false\"", value)
+					}
 				default:
 					return fmt.Errorf("unknown editor field %q; valid fields: name, command, terminal", field)
 				}

--- a/cmd/projector/delete.go
+++ b/cmd/projector/delete.go
@@ -106,6 +106,9 @@ func newDeleteCmd() *cobra.Command {
 
 			if deleteBranches && !force {
 				for _, wt := range worktrees {
+					if wt.branch == "" {
+						continue // detached worktrees have no branch to check
+					}
 					unpushed, err := git.HasUnpushedCommits(wt.repoPath, wt.branch)
 					if err != nil {
 						return fmt.Errorf("check unpushed commits for %s: %w", wt.repoName, err)
@@ -134,7 +137,7 @@ func newDeleteCmd() *cobra.Command {
 							fmt.Fprintf(os.Stderr, "    git worktree remove %s\n", wt.worktreePath)
 							hasAction = true
 						}
-						if deleteBranches {
+						if deleteBranches && wt.branch != "" {
 							fmt.Fprintf(os.Stderr, "    git branch -D %s  (in %s)\n", wt.branch, wt.repoPath)
 							hasAction = true
 						}
@@ -177,6 +180,9 @@ func newDeleteCmd() *cobra.Command {
 
 			if deleteBranches {
 				for _, wt := range worktrees {
+					if wt.branch == "" {
+						continue // detached worktrees have no branch to delete
+					}
 					fmt.Printf("  Deleting branch %q in %s...\n", wt.branch, wt.repoName)
 					if _, err := git.RunGit(wt.repoPath, "branch", "-D", wt.branch); err != nil {
 						return fmt.Errorf("delete branch %q in %s: %w", wt.branch, wt.repoName, err)

--- a/cmd/projector/open.go
+++ b/cmd/projector/open.go
@@ -162,7 +162,7 @@ func findEditor(editors []tui.EditorOption, command string) tui.EditorOption {
 // launchEditor opens projectDir in the specified editor.
 func launchEditor(editor tui.EditorOption, projectDir string) error {
 	if editor.Terminal {
-		fmt.Printf("To open in %s, run:\n\n  cd %s && %s\n", editor.Name, projectDir, editor.Command)
+		fmt.Printf("To open in %s, run:\n\n  cd %q && %s\n", editor.Name, projectDir, editor.Command)
 		return nil
 	}
 


### PR DESCRIPTION
Caught and fixed these issues in prepping a release candidate:

1. delete.go — --delete-branches no longer crashes on projects with detached worktrees (skips unpushed check, preview, and branch deletion for detached entries)
2. open.go — Terminal editor cd command now shell-quotes the project path so it works with spaces
3. addrepo.go — Added rollback on partial worktree creation failure (matches create.go behavior)
4. archive.go — Rollback now uses WorktreeAddDetached for detached worktrees instead of WorktreeAdd which would create a spurious branch
5. config_set.go — editors.<name>.terminal now rejects invalid values with a clear error instead of silently treating them as false