### PR TITLE
Change git worktree names to match git repo names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ All git operations go through `git.RunGit(workingDir, args...)`. Never shell out
 - No global state mutation in tests (use `t.Setenv` to override `HOME`).
 
 ### Worktree Naming Convention
-Worktree directories are named `<repo-name>+<project-name>`, e.g. `my-repo+feature-x`.
+Worktree directories are named after the original git repository directory, e.g. `my-repo`.
 
 ### Branch Name Strategy
 `AvailableBranchName` tries in order:

--- a/README.md
+++ b/README.md
@@ -392,17 +392,17 @@ Status:   active
 Created:  2 days ago
 
 my-api  [feature-x]
-  path    /Users/alice/projects/feature-x/my-api+feature-x
+  path    /Users/alice/projects/feature-x/my-api
   status  clean
 
 my-frontend  [feature-x]  dirty
-  path    /Users/alice/projects/feature-x/my-frontend+feature-x
+  path    /Users/alice/projects/feature-x/my-frontend
   status  dirty
      M  src/components/Button.tsx
     ??  src/components/NewComponent.tsx
 
 my-backend  [feature-x-2024]
-  path    /Users/alice/projects/feature-x/my-backend+feature-x
+  path    /Users/alice/projects/feature-x/my-backend
   status  clean
 ```
 
@@ -434,9 +434,9 @@ Before proceeding, the command previews the exact git commands it will run and s
 The following actions will be performed:
 
   api:
-    git worktree remove /Users/alice/projects/my-feature/api+my-feature
+    git worktree remove /Users/alice/projects/my-feature/api
   frontend:
-    git worktree remove /Users/alice/projects/my-feature/frontend+my-feature
+    git worktree remove /Users/alice/projects/my-feature/frontend
 
   rm -rf /Users/alice/projects/my-feature
 
@@ -476,12 +476,12 @@ For two repos (`git-repo-1`, `git-repo-2`) and two projects (`foo`, `bar`):
 ~/repos/git-repo-2
 ~/projects/foo/
   .projector.toml               # project metadata
-  git-repo-1+foo/               # git worktree (branch: foo)
-  git-repo-2+foo/               # git worktree (branch: foo)
+  git-repo-1/                   # git worktree (branch: foo)
+  git-repo-2/                   # git worktree (branch: foo)
 ~/projects/bar/
   .projector.toml
-  git-repo-1+bar/               # git worktree (branch: bar)
-  git-repo-2+bar/               # git worktree (branch: bar)
+  git-repo-1/                   # git worktree (branch: bar)
+  git-repo-2/                   # git worktree (branch: bar)
 ```
 
 ---

--- a/cmd/projector/addrepo.go
+++ b/cmd/projector/addrepo.go
@@ -293,7 +293,7 @@ func newAddRepoCmd() *cobra.Command {
 			}
 
 			for _, rr := range resolved {
-				worktreePath := filepath.Join(projectDir, rr.repo.Name+"+"+projectName)
+				worktreePath := filepath.Join(projectDir, rr.repo.Name)
 
 				if detached {
 					if err := git.WorktreeAddDetached(rr.repo.Path, worktreePath, rr.base); err != nil {

--- a/cmd/projector/create.go
+++ b/cmd/projector/create.go
@@ -296,7 +296,7 @@ func newCreateCmd() *cobra.Command {
 
 			// Phase 3: Create worktrees.
 			for _, rr := range resolved {
-				worktreePath := filepath.Join(projectDir, rr.repo.Name+"+"+name)
+				worktreePath := filepath.Join(projectDir, rr.repo.Name)
 
 				if detached {
 					if err := git.WorktreeAddDetached(rr.repo.Path, worktreePath, rr.base); err != nil {

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -29,10 +29,10 @@ Worktrees solve this by giving each task its own directory:
 ~/repos/my-api/                    # original clone (main branch)
 
 ~/projects/feature-x/
-    my-api+feature-x/              # worktree (feature-x branch)
+    my-api/                        # worktree (feature-x branch)
 
 ~/projects/bugfix-y/
-    my-api+bugfix-y/               # worktree (bugfix-y branch)
+    my-api/                        # worktree (bugfix-y branch)
 ```
 
 Each agent gets its own isolated workspace. No conflicts, no coordination needed. You can spin up a new task in seconds and tear it down when you're done — the branch stays in the original repo.
@@ -67,14 +67,14 @@ The result is a clean project directory you can open as a single workspace:
 ```
 ~/projects/feature-x/
     .projector.toml
-    api+feature-x/           # worktree of api repo
-    frontend+feature-x/      # worktree of frontend repo
-    infra+feature-x/         # worktree of infra repo
+    api/                     # worktree of api repo
+    frontend/                # worktree of frontend repo
+    infra/                   # worktree of infra repo
 
 ~/projects/bugfix-y/
     .projector.toml
-    api+bugfix-y/
-    frontend+bugfix-y/
+    api/
+    frontend/
 ```
 
 Each project is a self-contained workspace. Open it in Cursor, point Claude Code at it, or work in it yourself — all without touching any other project.

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -196,7 +196,7 @@ func TestDiscoverWorktrees(t *testing.T) {
 	projectDir := t.TempDir()
 
 	// Add a worktree into the project dir
-	worktreePath := filepath.Join(projectDir, "my-repo+myproject")
+	worktreePath := filepath.Join(projectDir, "my-repo")
 	if err := git.WorktreeAdd(repo, worktreePath, "HEAD", "myproject", true); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}


### PR DESCRIPTION
Previously, git worktree directory names defaulted to `{gitRepoName}+{projectName}`.

This changes the default directory name for git worktrees in a project to just `{gitRepoName}`, which is more intuitive for most users. The parent directory being the project directory is enough context for most situations.

This resolves #18.