### PR TITLE
Hand off Homebrew to a hand-maintained source-built formula in the tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,11 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # GoReleaser no longer manages Homebrew (the `brews` formula key was
+          # removed in GoReleaser v2.16). The pj formula is hand-maintained in
+          # kevdoran/homebrew-tap, so HOMEBREW_TAP_TOKEN is no longer consumed
+          # here. The secret is retained in the repo settings for any future
+          # tap automation.
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,17 +53,8 @@ changelog:
       - "^ci:"
       - "^chore:"
 
-brews:
-  - name: pj
-    homepage: "https://github.com/kevdoran/projector"
-    description: "Manage parallel projects backed by git worktrees"
-    repository:
-      owner: kevdoran
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    dependencies:
-      - name: git
-    install: |
-      bin.install "pj"
-    test: |
-      system "#{bin}/pj", "version"
+# Homebrew is intentionally NOT managed by GoReleaser.
+# The `brews` (formula) key was deprecated in GoReleaser v2.10 and removed in
+# v2.16, and GoReleaser can only emit binary `homebrew_casks` now — it cannot
+# generate a build-from-source formula. The `pj` formula is therefore
+# hand-maintained (build-from-source) in the kevdoran/homebrew-tap repo.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,7 @@ changelog:
       - "^ci:"
       - "^chore:"
 
-homebrew_casks:
+brews:
   - name: pj
     homepage: "https://github.com/kevdoran/projector"
     description: "Manage parallel projects backed by git worktrees"
@@ -62,4 +62,8 @@ homebrew_casks:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     dependencies:
-      - formula: git
+      - name: git
+    install: |
+      bin.install "pj"
+    test: |
+      system "#{bin}/pj", "version"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pj project create feature-x api frontend infra
 
 ```bash
 brew tap kevdoran/tap  # one-time command to add the kevdoran tap
-brew install --cask pj
+brew install pj
 ```
 
 Other methods: [binary download, from source](docs/install.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,6 +9,11 @@ brew tap kevdoran/tap  # one-time command to add the kevdoran tap
 brew install pj
 ```
 
+The `pj` formula is a build-from-source formula: Homebrew downloads the source
+tarball for the release tag and compiles it with `go build` on your machine
+(`go` is pulled in automatically as a build dependency). The `brew tap
+kevdoran/tap` shorthand maps to the `kevdoran/homebrew-tap` repository.
+
 To upgrade to the latest version:
 
 ```bash
@@ -28,6 +33,10 @@ brew uninstall --cask kevdoran/tap/pj
 brew tap kevdoran/tap  # one-time command to add the kevdoran tap
 brew install kevdoran/tap/pj
 ```
+
+Once a `tap_migrations.json` mapping the old cask to the new formula is added to
+the `kevdoran/homebrew-tap` repo, this migration will happen automatically and
+you can simply run `brew upgrade pj`.
 
 ## Binary download
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,27 +6,28 @@ Add the `kevdoran` homebrew tap, then install the `pj` formula:
 
 ```bash
 brew tap kevdoran/tap  # one-time command to add the kevdoran tap
-brew install --cask pj
+brew install pj
 ```
 
-To upgrade to the lastest version:
+To upgrade to the latest version:
 
 ```bash
-brew upgrade --cask pj
+brew upgrade pj
 ```
 
-<!-- ### Upgrading from v0.x (cask install)
+### Upgrading from a cask install
 
-Prior to v1.0.0, `pj` was distributed as a Homebrew cask. To migrate to the Homebrew formula:
+Earlier releases distributed `pj` as a Homebrew **cask**. It is now distributed
+as a Homebrew **formula**. If you previously installed the cask, migrate with:
 
 ```bash
-# uninstall from homebrew's cask directory
+# uninstall the old cask
 brew uninstall --cask kevdoran/tap/pj
 
-# install to homebrew's formula directory
+# install the formula (the tap is the same)
 brew tap kevdoran/tap  # one-time command to add the kevdoran tap
-brew install pj
-``` -->
+brew install kevdoran/tap/pj
+```
 
 ## Binary download
 


### PR DESCRIPTION
Closes #21

## Why this changed direction

The earlier version of this PR distributed `pj` via GoReleaser's `brews:` (formula) key. That key was **deprecated in GoReleaser v2.10 and removed in v2.16**, and our release workflow floats GoReleaser to `~> v2`, so the next release that picked up v2.16+ would fail to parse `.goreleaser.yaml`. GoReleaser can now only emit binary `homebrew_casks` — it cannot generate a build-from-source formula at all.

Per maintainer decision, **GoReleaser no longer manages Homebrew**. The Homebrew formula will be **hand-maintained, build-from-source, in the separate `kevdoran/homebrew-tap` repo**. This PR makes *this* repo consistent with that decision and hands over everything needed for the tap.

## What changed in this repo

- **`.goreleaser.yaml`** — removed the Homebrew block entirely (the `brews:` block this PR previously introduced) and replaced it with a comment explaining why Homebrew is no longer GoReleaser-managed. Builds, archives, notarize, checksum, and changelog are untouched — the release still produces the binaries/archives used by the "Binary download" install method.
- **`.github/workflows/release.yml`** — `HOMEBREW_TAP_TOKEN` was only ever passed to the (now-removed) GoReleaser Homebrew step, so it is no longer consumed. Removed it from the GoReleaser step's `env` and left a comment noting the secret is retained in repo settings for any future tap automation. The rest of the workflow is unchanged.
- **`docs/install.md`** — Homebrew section uses the **formula** form (`brew install pj` / `brew upgrade pj`, no `--cask`); added a note that the formula builds from source with `go build` (Homebrew pulls in `go` as a build dependency). The cask→formula migration section is corrected (`brew uninstall --cask kevdoran/tap/pj` then `brew install kevdoran/tap/pj`) and notes that a `tap_migrations.json` in the tap will eventually automate this.
- **`README.md`** / **`pj-skill.md`** — already used the formula form; consistent on `brew tap kevdoran/tap` (which Homebrew expands to `kevdoran/homebrew-tap`).

`go build ./cmd/projector` and `go vet ./...` both pass (packaging/docs change only, no Go code touched).

## Follow-up in the tap repo (not editable from here)

Add the build-from-source formula below as `Formula/pj.rb` in `kevdoran/homebrew-tap`, plus a `tap_migrations.json` so existing cask users auto-migrate. Once those land, cask users can simply `brew upgrade pj`.

### `Formula/pj.rb` (ready to paste)

```ruby
class Pj < Formula
  desc "Manage parallel projects backed by git worktrees"
  homepage "https://github.com/kevdoran/projector"
  url "https://github.com/kevdoran/projector/archive/refs/tags/v0.5.0.tar.gz"
  sha256 "REPLACE_WITH_SHA256_OF_THE_SOURCE_TARBALL"
  license "Apache-2.0"
  head "https://github.com/kevdoran/projector.git", branch: "main"

  depends_on "go" => :build
  depends_on "git"

  def install
    commit   = Utils.git_short_head(length: 7) rescue "unknown"
    build_date = Time.now.utc.strftime("%Y-%m-%d")
    ldflags = %W[
      -s -w
      -X main.version=#{version}
      -X main.commit=#{commit}
      -X main.buildDate=#{build_date}
    ]
    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/projector"
  end

  test do
    assert_match version.to_s, shell_output("#{bin}/pj version")
  end
end
```

Notes:
- The `url` / `sha256` track the GitHub source tarball for each release tag. Get the checksum with `curl -sL <url> | shasum -a 256`. (Homebrew's `brew bump-formula-pr` automates this on subsequent bumps.)
- `std_go_args` already sets `-o #{bin}/pj` and the build mod flags; we only add the version ldflags. The ldflags mirror the repo's `Makefile` and the (now-removed) `.goreleaser.yaml` builds block: `-X main.version=… -X main.commit=… -X main.buildDate=…`, main package `./cmd/projector`.
- The `test do` block asserts `pj version` prints the version string.

### `tap_migrations.json` (ready to paste)

```json
{
  "pj": "kevdoran/tap/pj"
}
```

This maps the old `kevdoran/tap/pj` **cask** to the new **formula**, so Homebrew auto-migrates existing cask installs on the next `brew upgrade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
