### PR TITLE
Move global config to XDG location (~/.config/projector/config.toml)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ go test -v -race -count=1 ./internal/git/...
 | Package | Responsibility |
 |---|---|
 | `cmd/projector` | Cobra root + one file per subcommand (`projects.go`, `list.go`, `create.go`, `desc.go`, `open.go`, `path.go`, `addrepo.go`, `archive.go`, `restore.go`, `delete.go`, `version.go`, `config.go`, `config_run.go`, `config_list.go`, `config_get.go`, `config_set.go`, `config_unset.go`). No business logic — delegate to internal packages. |
-| `internal/config` | `GlobalConfig` struct, `EditorConfig` struct, `Load`/`Save`/`ResolveBase`/`Validate`. TOML I/O for `~/.projector/projector-config.toml`. |
+| `internal/config` | `GlobalConfig` struct, `EditorConfig` struct, `Load`/`Save`/`ResolveBase`/`Validate`. TOML I/O for `~/.config/projector/config.toml` (honors `$XDG_CONFIG_HOME`); `Load` falls back to and copy-migrates the legacy `~/.projector/projector-config.toml`. |
 | `internal/project` | `ProjectConfig` struct, `Load`/`Save`/`ListAll`/`FindProjectDir`/`ValidateName`/`DiscoverWorktrees`. TOML I/O for `<projects-dir>/<name>/.projector.toml`. |
 | `internal/git` | Thin wrappers around the `git` executable: `RunGit`, `WorktreeAdd`, `WorktreeAddDetached`, `WorktreeRemove`, `WorktreeList`, `WorktreeForBranch`, `StatusPorcelain`, `RefExists`, `BranchExists`, `BranchCheckedOut`, `CurrentBranch`, `AvailableBranchName`, `BranchNameFromRef`, `Remotes`, `DefaultRemote`, `RemoteForRef`, `Fetch`, `FetchRef`, `HasUnpushedCommits`, `HeadSHA`, `MinVersionCheck`. |
 | `internal/repo` | `Repo` struct, `Discover` (non-recursive scan of search dirs), `ResolveRepos` (name or abs-path lookup). |

--- a/cmd/projector/config.go
+++ b/cmd/projector/config.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Manage global configuration (~/.projector/projector-config.toml)",
+		Short: "Manage global configuration (~/.config/projector/config.toml)",
 	}
 	cmd.AddCommand(
 		newConfigSetupCmd(),

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,7 +14,10 @@ Sets up:
 - **Projects directory** — where project directories are created (e.g. `~/code/projects`)
 - **Repository search directories** — directories scanned for git repos (e.g. `~/code/repos/work,~/code/repos/personal`)
 
-Configuration is saved to `~/.projector/projector-config.toml`.
+Configuration is saved to `~/.config/projector/config.toml` (honoring
+`$XDG_CONFIG_HOME` if set). For backwards compatibility, if a config exists only
+at the legacy location `~/.projector/projector-config.toml`, it is read and
+copied to the new location on first use (the legacy file is left in place).
 
 ### `pj config list`
 
@@ -221,7 +224,7 @@ To open in Claude Code, run:
   cd /Users/alice/projects/my-feature && claude
 ```
 
-**Custom editors** — define additional editors in `~/.projector/projector-config.toml`:
+**Custom editors** — define additional editors in `~/.config/projector/config.toml`:
 ```toml
 default-editor = "cursor"
 
@@ -358,7 +361,7 @@ Output:
 
 ## Configuration File
 
-`~/.projector/projector-config.toml`:
+`~/.config/projector/config.toml`:
 
 ```toml
 projects-dir = "/Users/alice/projects"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,8 +17,15 @@ import (
 var ErrNotFound = errors.New("config file not found")
 
 const (
-	configDirName  = ".projector"
-	configFileName = "projector-config.toml"
+	// New (preferred) XDG-style location: $XDG_CONFIG_HOME/projector/config.toml
+	// (defaulting to ~/.config/projector/config.toml).
+	configSubdir   = "projector"
+	configFileName = "config.toml"
+
+	// Legacy location: ~/.projector/projector-config.toml. Still read for
+	// backwards compatibility, and migrated to the new location on load.
+	legacyConfigDirName  = ".projector"
+	legacyConfigFileName = "projector-config.toml"
 
 	// CurrentConfigVersion is the config schema version written by this binary.
 	// Increment when a migration is needed; Load will reject files with a higher version.
@@ -28,7 +35,7 @@ const (
 // ErrConfigVersionTooNew is returned when the config file was written by a newer version of projector.
 var ErrConfigVersionTooNew = errors.New("config file was written by a newer version of projector; please upgrade")
 
-// GlobalConfig is the top-level structure for ~/.projector/projector-config.toml.
+// GlobalConfig is the top-level structure for ~/.config/projector/config.toml.
 type GlobalConfig struct {
 	ConfigVersion  int                      `toml:"config-version"`
 	ProjectsDir    string                   `toml:"projects-dir"`
@@ -50,16 +57,22 @@ type RepoConfig struct {
 	DefaultBase string `toml:"default-base"`
 }
 
-// ConfigDir returns the path to the projector config directory (~/.projector).
+// ConfigDir returns the path to the projector config directory
+// ($XDG_CONFIG_HOME/projector, defaulting to ~/.config/projector).
 func ConfigDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("home dir: %w", err)
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("home dir: %w", err)
+		}
+		base = filepath.Join(home, ".config")
 	}
-	return filepath.Join(home, configDirName), nil
+	return filepath.Join(base, configSubdir), nil
 }
 
-// ConfigFilePath returns the full path to projector-config.toml.
+// ConfigFilePath returns the full path to the config file in the new
+// (preferred) location: $XDG_CONFIG_HOME/projector/config.toml.
 func ConfigFilePath() (string, error) {
 	dir, err := ConfigDir()
 	if err != nil {
@@ -68,8 +81,26 @@ func ConfigFilePath() (string, error) {
 	return filepath.Join(dir, configFileName), nil
 }
 
+// legacyConfigFilePath returns the full path to the legacy config file
+// (~/.projector/projector-config.toml).
+func legacyConfigFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, legacyConfigDirName, legacyConfigFileName), nil
+}
+
 // Load reads and parses the global config file.
-// Returns ErrNotFound if the file does not exist.
+//
+// Resolution order:
+//  1. The new (preferred) location $XDG_CONFIG_HOME/projector/config.toml.
+//  2. The legacy location ~/.projector/projector-config.toml. When the config
+//     is found only here, it is migrated (copied) to the new location so future
+//     loads use it; the legacy file is left in place for compatibility with
+//     older pj binaries. A message is printed to stdout describing the copy.
+//
+// Returns ErrNotFound if neither file exists.
 func Load() (*GlobalConfig, error) {
 	path, err := ConfigFilePath()
 	if err != nil {
@@ -77,9 +108,29 @@ func Load() (*GlobalConfig, error) {
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, ErrNotFound
+		// New location missing — fall back to the legacy location.
+		legacyPath, lerr := legacyConfigFilePath()
+		if lerr != nil {
+			return nil, lerr
+		}
+		if _, lerr := os.Stat(legacyPath); os.IsNotExist(lerr) {
+			return nil, ErrNotFound
+		}
+		// Migrate (copy) legacy → new so future loads use the new location.
+		if merr := migrateLegacyConfig(legacyPath, path); merr != nil {
+			// Migration is best-effort; if it fails, still load from the
+			// legacy file rather than failing the whole command.
+			return loadFile(legacyPath)
+		}
+		fmt.Printf("Migrated projector config to %s (copied from %s; the old file was left in place).\n", path, legacyPath)
+		return loadFile(path)
 	}
 
+	return loadFile(path)
+}
+
+// loadFile parses a single config file at the given path.
+func loadFile(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{}
 	if _, err := toml.DecodeFile(path, cfg); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
@@ -89,6 +140,22 @@ func Load() (*GlobalConfig, error) {
 			ErrConfigVersionTooNew, cfg.ConfigVersion, CurrentConfigVersion)
 	}
 	return cfg, nil
+}
+
+// migrateLegacyConfig copies the legacy config file to the new location,
+// creating the destination directory if needed. The source is left untouched.
+func migrateLegacyConfig(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read legacy config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(dst, data, 0644); err != nil {
+		return fmt.Errorf("write migrated config: %w", err)
+	}
+	return nil
 }
 
 const editorComment = `# default-editor: editor command used by "pj project open" without prompting.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,7 +122,7 @@ func Load() (*GlobalConfig, error) {
 			// legacy file rather than failing the whole command.
 			return loadFile(legacyPath)
 		}
-		fmt.Printf("Migrated projector config to %s (copied from %s; the old file was left in place).\n", path, legacyPath)
+		fmt.Fprintf(os.Stderr, "Migrated projector config to %s (copied from %s; the old file was left in place).\n", path, legacyPath)
 		return loadFile(path)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,17 +4,43 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kevdoran/projector/internal/config"
 )
 
-// writeCfgFile writes a TOML config file to a temp dir and patches HOME.
+// withTempHome patches HOME (and unsets XDG_CONFIG_HOME) to an isolated temp
+// dir so config resolution stays self-contained. Returns the temp home.
 func withTempHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
 	return home
+}
+
+// newConfigPath returns the path to the new-location config file under home:
+// <home>/.config/projector/config.toml.
+func newConfigPath(home string) string {
+	return filepath.Join(home, ".config", "projector", "config.toml")
+}
+
+// legacyConfigPath returns the path to the legacy config file under home:
+// <home>/.projector/projector-config.toml.
+func legacyConfigPath(home string) string {
+	return filepath.Join(home, ".projector", "projector-config.toml")
+}
+
+// writeFile writes content to path, creating parent dirs.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestLoad_ErrNotFound(t *testing.T) {
@@ -77,18 +103,11 @@ func TestSave_And_Load_RoundTrip(t *testing.T) {
 
 func TestLoad_IgnoresOldEditorField(t *testing.T) {
 	home := withTempHome(t)
-	cfgDir := filepath.Join(home, ".projector")
-	if err := os.MkdirAll(cfgDir, 0755); err != nil {
-		t.Fatal(err)
-	}
 	// Simulate an old config file with the deprecated "editor" field.
-	content := `config-version = 1
+	writeFile(t, newConfigPath(home), `config-version = 1
 projects-dir = "/tmp/projects"
 editor = "code"
-`
-	if err := os.WriteFile(filepath.Join(cfgDir, "projector-config.toml"), []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
+`)
 	loaded, err := config.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -104,14 +123,7 @@ editor = "code"
 
 func TestLoad_ErrConfigVersionTooNew(t *testing.T) {
 	home := withTempHome(t)
-	cfgDir := filepath.Join(home, ".projector")
-	if err := os.MkdirAll(cfgDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	content := "config-version = 9999\nprojects-dir = \"/tmp/projects\"\n"
-	if err := os.WriteFile(filepath.Join(cfgDir, "projector-config.toml"), []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, newConfigPath(home), "config-version = 9999\nprojects-dir = \"/tmp/projects\"\n")
 	_, err := config.Load()
 	if !errors.Is(err, config.ErrConfigVersionTooNew) {
 		t.Fatalf("expected ErrConfigVersionTooNew, got %v", err)
@@ -120,16 +132,118 @@ func TestLoad_ErrConfigVersionTooNew(t *testing.T) {
 
 func TestLoad_ParseError(t *testing.T) {
 	home := withTempHome(t)
-	cfgDir := filepath.Join(home, ".projector")
-	if err := os.MkdirAll(cfgDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "projector-config.toml"), []byte("not = valid [toml"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, newConfigPath(home), "not = valid [toml")
 	_, err := config.Load()
 	if err == nil {
 		t.Fatal("expected parse error")
+	}
+}
+
+// TestSave_WritesToNewLocation verifies Save targets the new XDG location.
+func TestSave_WritesToNewLocation(t *testing.T) {
+	home := withTempHome(t)
+	if err := config.Save(&config.GlobalConfig{ProjectsDir: "/tmp/projects"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(newConfigPath(home)); err != nil {
+		t.Errorf("expected config at new location %s: %v", newConfigPath(home), err)
+	}
+	if _, err := os.Stat(legacyConfigPath(home)); !os.IsNotExist(err) {
+		t.Errorf("Save should not write to the legacy location")
+	}
+}
+
+// TestConfigFilePath_DefaultsToXDGConfigHome verifies the path uses ~/.config
+// when XDG_CONFIG_HOME is unset.
+func TestConfigFilePath_DefaultsToXDGConfigHome(t *testing.T) {
+	home := withTempHome(t)
+	path, err := config.ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+	if path != newConfigPath(home) {
+		t.Errorf("ConfigFilePath: got %q, want %q", path, newConfigPath(home))
+	}
+}
+
+// TestConfigFilePath_HonorsXDGConfigHome verifies $XDG_CONFIG_HOME override.
+func TestConfigFilePath_HonorsXDGConfigHome(t *testing.T) {
+	withTempHome(t)
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	path, err := config.ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+	want := filepath.Join(xdg, "projector", "config.toml")
+	if path != want {
+		t.Errorf("ConfigFilePath: got %q, want %q", path, want)
+	}
+}
+
+// TestLoad_PrefersNewOverLegacy verifies the new location wins when both exist.
+func TestLoad_PrefersNewOverLegacy(t *testing.T) {
+	home := withTempHome(t)
+	writeFile(t, newConfigPath(home), "config-version = 1\nprojects-dir = \"/new/projects\"\n")
+	writeFile(t, legacyConfigPath(home), "config-version = 1\nprojects-dir = \"/legacy/projects\"\n")
+
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ProjectsDir != "/new/projects" {
+		t.Errorf("ProjectsDir: got %q, want %q (new location should win)", loaded.ProjectsDir, "/new/projects")
+	}
+	// Legacy file must be left untouched.
+	data, err := os.ReadFile(legacyConfigPath(home))
+	if err != nil {
+		t.Fatalf("read legacy: %v", err)
+	}
+	if !strings.Contains(string(data), "/legacy/projects") {
+		t.Errorf("legacy file should be unchanged, got: %s", data)
+	}
+}
+
+// TestLoad_MigratesLegacyToNew verifies that when only the legacy config
+// exists, Load copies it to the new location and leaves the legacy file in place.
+func TestLoad_MigratesLegacyToNew(t *testing.T) {
+	home := withTempHome(t)
+	legacyContent := "config-version = 1\nprojects-dir = \"/legacy/projects\"\n"
+	writeFile(t, legacyConfigPath(home), legacyContent)
+
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ProjectsDir != "/legacy/projects" {
+		t.Errorf("ProjectsDir: got %q, want %q", loaded.ProjectsDir, "/legacy/projects")
+	}
+
+	// New location must now exist with the migrated content.
+	newData, err := os.ReadFile(newConfigPath(home))
+	if err != nil {
+		t.Fatalf("expected migrated config at new location: %v", err)
+	}
+	if string(newData) != legacyContent {
+		t.Errorf("migrated content mismatch: got %q, want %q", newData, legacyContent)
+	}
+
+	// Legacy file must be left in place (copy, not move).
+	if _, err := os.Stat(legacyConfigPath(home)); err != nil {
+		t.Errorf("legacy file should be left in place after migration: %v", err)
+	}
+
+	// A subsequent Load should read from the new location without error.
+	if _, err := config.Load(); err != nil {
+		t.Fatalf("second Load after migration: %v", err)
+	}
+}
+
+// TestLoad_NoConfigAnywhere verifies ErrNotFound when neither location exists.
+func TestLoad_NoConfigAnywhere(t *testing.T) {
+	withTempHome(t)
+	if _, err := config.Load(); !errors.Is(err, config.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
 

--- a/pj-skill.md
+++ b/pj-skill.md
@@ -35,7 +35,7 @@ brew upgrade pj   # if installed via Homebrew
 
 - **Project**: a named directory (`<projects-dir>/<name>/`) containing one git worktree per repository
 - **Worktree**: a linked working tree from a git repository, checked out at a branch named after the project
-- **Projects directory**: configured at `~/.projector/projector-config.toml` (`projects-dir` key)
+- **Projects directory**: configured at `~/.config/projector/config.toml` (`projects-dir` key)
 
 ## Essential Commands
 


### PR DESCRIPTION
## What & why

Closes #22. Moves the default global config from `~/.projector/projector-config.toml` to the XDG-style `~/.config/projector/config.toml`, matching the conventions used by `gh`, `mise`, and `iterm2` and reducing home-directory clutter.

`ConfigDir`/`ConfigFilePath` now honor `$XDG_CONFIG_HOME`:
- If `$XDG_CONFIG_HOME` is set: `$XDG_CONFIG_HOME/projector/config.toml`.
- Otherwise: `~/.config/projector/config.toml` (XDG default base `~/.config`).

## Backwards-compatibility / resolution order

`config.Load()` resolves in this order:
1. New location (`$XDG_CONFIG_HOME/projector/config.toml`, default `~/.config/projector/config.toml`) — preferred.
2. Legacy location (`~/.projector/projector-config.toml`) — fallback when the new file is absent.
3. Neither present → `ErrNotFound` (treated as not-yet-configured, same as before).

`config.Save()` always writes to the **new** location.

## Migration semantics: copy, not move

When the config exists **only** at the legacy location, `Load` **copies** it to the new location (creating `~/.config/projector/`), leaves the legacy file untouched, and prints a one-line notice to stdout:

```
Migrated projector config to <new> (copied from <legacy>; the old file was left in place).
```

Rationale for copy-vs-move: copying is the safer choice for users who may still run an older `pj` binary that only reads the legacy path — both binaries keep working. Migration is best-effort: if the copy fails (e.g. read-only `~/.config`), `Load` still loads directly from the legacy file rather than failing the command. Since `Save` targets the new location, the two files can diverge after a subsequent write; this is the accepted trade-off for keeping older binaries functional, and `Load` always prefers the new file once it exists.

## Tests

Added/updated tests in `internal/config/config_test.go`:
- new location preferred over legacy (and legacy left unchanged)
- legacy → new copy-migration (new file created, legacy preserved, second load reads new)
- `$XDG_CONFIG_HOME` override and default-to-`~/.config`
- `Save` writes to new location only
- no-config-anywhere → `ErrNotFound`

The shared test helper now also clears `XDG_CONFIG_HOME` to keep resolution self-contained.

## Docs

Updated `docs/commands.md` (incl. a note on the XDG location + legacy fallback/migration), `CLAUDE.md` (config package row), `pj-skill.md`, and the `pj config` command `Short` help text.

## Verification

Locally: `go build ./cmd/projector`, `go vet ./...`, and `go test -race -count=1 ./...` all pass.

## For reviewers to scrutinize / not verified locally

- Real-world cross-binary behavior (old `pj` reading legacy while new `pj` reads/writes the new path) is reasoned about, not exercised in CI.
- The migration message goes to **stdout**; if any command's stdout is machine-parsed, this one-time line could be unexpected. It only prints on the first load after the file exists solely at the legacy path.
- `$XDG_CONFIG_HOME` is used verbatim if set; no validation that it is an absolute path (matches typical XDG tooling behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)